### PR TITLE
provisional timetable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,7 +52,7 @@ collections:
 header_pages:
   - _magpie24/call.md
   - _magpie24/registration.md
-  - _magpie24/timetable.md
+ # - _magpie24/timetable.md
   - about.md
 
 include:

--- a/_events/magpie24/a1_PreEvent_installation-help-morning.md
+++ b/_events/magpie24/a1_PreEvent_installation-help-morning.md
@@ -1,0 +1,12 @@
+---
+layout: event
+title:  "PreEvent - Morning - MAgPIE intro & installation help"
+event_start:   "2024-04-05T09:00:00+01:00"
+event_end:     "2024-04-05T10:00:00+01:00"
+agenda:
+  - title: Interactive help session
+    length: 60
+    presenter: MAgPIE team
+---
+
+At this pre-event we will offer a interactive Q&A session to help with installation problems. Please try to install the model in advance!

--- a/_events/magpie24/a2_PreEvent_installation-help-afternoon.md
+++ b/_events/magpie24/a2_PreEvent_installation-help-afternoon.md
@@ -1,0 +1,12 @@
+---
+layout: event
+title:  "PreEvent - Evening - MAgPIE intro & installation help"
+event_start:   "2024-04-05T15:00:00+01:00"
+event_end:     "2024-04-05T16:00:00+01:00"
+agenda:
+  - title: Interactive help session
+    length: 60
+    presenter: MAgPIE team
+---
+
+At this pre-event we will offer a interactive Q&A session to help with installation problems. Please try to install the model in advance!

--- a/_events/magpie24/b1_workshop1_What-is-MAgPIE.md
+++ b/_events/magpie24/b1_workshop1_What-is-MAgPIE.md
@@ -1,0 +1,19 @@
+---
+layout: event
+title:  "Workshop 1 - What is MAgPIE"
+event_start:   "2024-04-10T09:00:00+01:00"
+event_end:     "2024-04-10T11:00:00+01:00"
+
+agenda:
+  - title: Welcome & agenda
+    length: 10
+    presenter: jpd 
+  - title: What is MAgPIE?
+    url: https://slides.com/jandietrich/magpie-4-0/
+    length: 50
+    presenter: jpd
+  - shortID: git
+    length: 40
+    presenter: kk
+---
+In the first workshop we will give a short overview about what the [MAgPIE](https://github.com/magpiemodel/magpie) framework is, how it looks like, and what it is used for. This is followed by the first of the interactive tutorials which will give a brief introduction into the version control management of MAgPIE via git/github.

--- a/_events/magpie24/b2_workshop2_Getting-to-know-the-model.md
+++ b/_events/magpie24/b2_workshop2_Getting-to-know-the-model.md
@@ -1,0 +1,19 @@
+---
+layout: event
+title:  "Workshop 2 - Model code overview"
+event_start:   "2024-04-10T12:00:00+01:00"
+event_end:     "2024-04-10T14:00:00+01:00"
+
+agenda:
+  - shortID: gams
+    length: 40
+    presenter: emb
+  - shortID: goxygen
+    length: 30
+    presenter: kk 
+  - shortID: renv 
+    length: 45 
+    presenter: ps
+---
+
+This workshop session will give you an overview about the model code, how it is managed and how it is read. The first tutorial will give an overview about the GAMS code and its underlying modules and realizations. The next tutorial will focus on the model documentation, where it can be found and how it is created. The final tutorial of the session will focus on how the  projects package dependencies are managed using [renv](https://rstudio.github.io/renv/index.html). 

--- a/_events/magpie24/b3_workshop3_First-steps.md
+++ b/_events/magpie24/b3_workshop3_First-steps.md
@@ -1,0 +1,21 @@
+---
+layout: event
+title:  "Workshop 3 - First steps"
+event_start:   "2024-04-11T09:00:00+01:00"
+event_end:     "2024-04-11T11:00:00+01:00"
+agenda:
+  - title: Welcome back
+    length: 5
+    presenter: jpd 
+  - shortID: start
+    length: 40
+    presenter: emb
+  - shortID: config
+    length: 35
+    presenter: dl
+  - shortID: startScript
+    length: 40
+    presenter: dh
+---
+
+This event will show you the basics necessary to run MAgPIE: How is a model run started? How can the settings of a run be adjusted? And how can an experiment setup be described and started via a custom start script?

--- a/_events/magpie24/b4_workshop4_Analysing-outputs.md
+++ b/_events/magpie24/b4_workshop4_Analysing-outputs.md
@@ -1,0 +1,18 @@
+---
+layout: event
+title:  "Workshop 4 - Analyse outputs"
+event_start:   "2024-04-11T12:00:00+01:00"
+event_end:     "2024-04-11T14:00:00+01:00"
+agenda:
+  - title: Welcome back
+    length: 5
+    presenter: jpd
+  - shortID: output
+    length: 60
+    presenter: pj
+  - shortID: output2
+    length: 50
+    presenter: fb
+---
+
+After having learned how to start MAgPIE this session will focus on how to analyze its outputs. The session is split into two parts with the first part focusing on regional outputs whereas the second part will deal with spatially more explicit, gridded model outputs.

--- a/_events/magpie24/b5_workshop5_Tweaking-the-model.md
+++ b/_events/magpie24/b5_workshop5_Tweaking-the-model.md
@@ -1,0 +1,21 @@
+---
+layout: event
+title:  "Workshop 5 - Tweaking the model"
+event_start:   "2024-04-12T09:00:00+01:00"
+event_end:     "2024-04-12T11:00:00+01:00"
+agenda:
+  - title: Welcome back
+    length: 5
+    presenter: jpd 
+  - shortID: changeCode
+    length: 55
+    presenter: fh
+  - shortID: pr
+    length: 15
+    presenter: mc
+  - shortID: changeInput
+    length: 45
+    presenter: ms
+---
+
+This session focuses on what to do if the available options are not sufficient and you have to go beyond what has already been implemented. You will learn how you can change the GAMS code as well as how to change model inputs. And it will be explained how these changes can be made available to the whole community via pull requests to the main repository.

--- a/_events/magpie24/b6_workshop6_Updating-inputs.md
+++ b/_events/magpie24/b6_workshop6_Updating-inputs.md
@@ -1,0 +1,21 @@
+---
+layout: event
+title:  "Workshop 6 - Updating input data"
+event_start:   "2024-04-12T12:00:00+01:00"
+event_end:     "2024-04-12T15:00:00+01:00"
+agenda:
+  - title: Welcome back
+    length: 5
+    presenter: jpd 
+  - shortID: madrat
+    length: 90 
+    presenter: dc
+  - shortID: magclass 
+    length: 75 
+    presenter: jpd
+---
+
+The last part of the workshop will focus on the data preparation for model applications and will provide a brief introduction to the [madrat] data processing framework, and its primary data structure [magclass]. These libraries are used for the full data processing chain for the MAgPIE model.
+
+[madrat]:https://github.com/pik-piam/madrat
+[magclass]:https://github.com/pik-piam/magclass

--- a/_events/magpie24/c1_stories1_MAgPIE-stories.md
+++ b/_events/magpie24/c1_stories1_MAgPIE-stories.md
@@ -1,0 +1,44 @@
+---
+layout: event
+title:  "Stories 1 - MAgPIE stories #1"
+event_start:   "2024-04-10T14:30:00+01:00"
+event_end:     "2024-04-10T16:00:00+01:00"
+agenda:
+  - title: Welcome
+    length: 10
+    presenter: jpd 
+  - title: Assessing the feasibility of combined climate-biodiversity policies in MAgPIE-MESSAGE
+    abstract: "We have created a new integrated assessment framework for the land-energy nexus by soft-coupling MAgPIE and MESSAGEix through a land-use emulator. In this approach, we modify MAgPIE to provide bioenergy potentials based on different policies and biomass prices. Then, we fix these potentials as demands and test carbon price sensitivities to assess land-use emissions under various carbon policies. Combining these two dimensions, we receive a scenario matrix functioning as parameter input for the energy model MESSAGE. We created several such matrices for various biodiversity policies, affecting both bioenergy potentials and land-use carbon emissions. "
+    length: 15
+    presenter: Jan Steinhauser
+    institution: IIASA/PIK
+    country: Austria 
+  - title: "Exploring temperature overshoot scenarios in a Land-Energy-Climate nexus"
+    abstract: "My work builds on the MESSAGE-MAgPIE emulator developed by Jan Steinhauser, and supports the work of Ron Milo's group from Weizmann (in collaboration IIASA and colleagues from PIK), both of which are also presented in MAgPIE stories. In this short section, I will talk about soft-coupling the emulator to MAGICC, the statistical climate model from IIASA, to explore global mean surface temperature overshoot beyond the most ambitious 1.5 °C target agreed in the Paris agreement. This gives us the technical tool to systematically explore Land-Energy-Climate scenarios."
+    length: 15
+    presenter: Sreyam Sengupta
+    institution: IIASA
+    country: Austria
+  - title: "Towards an integrated assessment of microbial protein production from CO2 and H2"
+    abstract: "Here, we determined the environmental benefits of substituting ruminant meat with protein from microbes that grow on H2 and CO2. Using historical data on margarine, a successful analog for an animal-based product, we derived growth projections for microbial protein substitution of ruminant meats. We used these projections in a novel linkage of the MESSAGE-MAgPIE models and analyzed their impacts on the global land-energy-water nexus. Upon substitution, we observed notable improvements in key environmental indicators: natural land, biodiversity, land emissions, water withdrawal and fertilizer use. We also explored the impact of different climate and biodiversity policies. We found microbial scenarios show promise in achieving more ambitious climate targets even under stringent biodiversity policy. Furthermore, the microbial scenario exhibits a reduced carbon price, while  attaining the same climate targets, underscoring its potential as an economically beneficial protein alternative."
+    length: 15
+    presenter: Roee Ben Nissan
+    institution: Weizmann institute of Science
+    country: Israel
+  - title: "Sustainable intensification of grazing systems with managed pastures implementation"
+    abstract: "Despite its role in diet shift scenarios, the livestock sector has received relatively less attention than crops in IAM development. I propose to oresent my work on sustainable intensification of grazing production systems made possible by the separation of managed pastures from rangelands and the creation if a oastures specific Tau factor. I will describe recent applications of these features in the FSEC, Nature Fiinance and Climate Advisers projects, and present proposals for anfuture research agenda."
+    length: 15
+    presenter: Alexandre Koberle
+    institution: University of Lisbon
+    country: Portugal
+  - title: "Integrating modelling and policy: insights from FSEC's study design"
+    abstract: "Many food system actors emphasise the critical role of the global food system in achieving sustainable, inclusive, and climate-friendly future, and advocate for science-based pathways to inform policy. Developing such pathways requires modelling to test targets, explore options, address trade-offs and provide a coherent vision. The MAgPIE framework supports this research by projecting changes considering socio-economic and biophysical factors. However, the findings of the FSEC show that transformation requires a nuanced policy response. Implementing a pathway such as Food System Transformation requires a policy framework that emphasises coherence, bundling, and coordinated governance. Evidence-based, transparent and nuanced policy design ensures effective transformation. Modelling, coupled with a robust policy framework, demonstrates the feasibility and necessity of global food system transformation. FSEC's approach exemplifies integrated study designs, combining modelling and policy."
+    length: 15
+    presenter: Claudia Hunecke
+    institution: PIK
+    country: Germany
+---
+
+The first of two MAgPIE stories sessions in which MAgPIE user and developer
+share talk about their MAgPIE-based research and share their experiences (click
+on the arrows to see the abstracts for each talk).

--- a/_events/magpie24/c2_stories2_MAgPIE-stories.md
+++ b/_events/magpie24/c2_stories2_MAgPIE-stories.md
@@ -1,0 +1,48 @@
+---
+layout: event
+title:  "Stories 2 - MAgPIE stories #2"
+event_start:   "2024-04-11T14:30:00+01:00"
+event_end:     "2024-04-11T16:00:00+01:00"
+agenda:
+  - title: Welcome
+    length: 10
+    presenter: jpd 
+  - title: "Enhancing governance performance in Sub-Saharan Africa boosts climate mitigation and food security"
+    abstract: "The Sub-Saharan Africa (SSA) region has experienced substantial population growth over the past decades while exhibiting weak governance, contributing to unsustainable agricultural production and land use. However, the importance of governance in improving food security and mitigating environmental degradation has been limited explored. Using an agro-economic dynamic optimization model, we investigate the impacts of governance performance on land use patterns, greenhouse gas (GHG) emissions, and food security in SSA region. Our findings underscore that improving governance performance could reduce emissions while ensure food security. Strong governance leads to less deforestation, further reducing GHG emissions in the Agriculture, Forestry, and Other Land Use (AFOLU) sector. Meanwhile, the scenario representing strong governance achieves higher crop yields, lower food prices and food expenditure, as well as improved self-sufficiency."
+    length: 15
+    presenter: Ruiying Du
+    institution: Zhejiang University
+    country: China
+  - title: "Fertilizer Subsidy Removal, Nitrogen Taxation and Pollution Reduction: A Comparative Analysis in China"
+    abstract: "Fertilizer manufacturing subsidies (FMS) are recognized as an important factor contributing to China's excessive fertilizer use by reducing fertilizer prices. In an effort to address this overuse, the Chinese government had phased out FMS by 2015. This study presents a comparative analysis of two environmental policies—fertilizer manufacturing subsidy removal and nitrogen taxation—on nitrogen pollution emissions and food security. Using an agro-economic land system model (MAgPIE), we find that imposing a nitrogen taxation is more effective for controlling nitrogen pollution emissions compared to FMS removal, based on nitrogen pollution reductions per unit cost. However, nitrogen taxation could lead to higher food prices and lower self-sufficiency, while FMS removal has marginal impacts on food security. An uncertainty analysis of fertilizer price is conducted through Monte Carlo simulation, highlighting the robustness of our model results."
+    length: 15
+    presenter: Meng Xu
+    institution: Zhejiang University
+    country: China
+  - title: "Sustainable agricultural development strategies in India"
+    abstract: "I intend to start my PhD journey with MAgPIE as the primary tool, where my research will focus on regional spatial analysis aimed at mapping future land-use patterns, incorporating an analysis of the probability of adopting new agricultural innovations and their impacts on major climate indicators. This will involve integration of empirical analysis using data from national and global datasets, for India. 
+    A key part of my activities will be to identify the representation of feed baskets for India within MAgPIE and improve the accounting within the model. For this, I will be working on internal R packages (mruniverse, magclass, etc.) and try to improve the representation of feed baskets and livestock productivity in the model, for India. Through these ideas, combined with the modularity and spatio-temporal flexibility in MAgPIE, I seek to contribute valuable insights into the direction of sustainable agricultural practices in India."
+    length: 15 
+    presenter: Ankit Saha
+    institution: Indian Institute of Management Ahmedabad
+    country: India
+  - title: "UN PRI Inevitable Policy Response 2023"
+    abstract: "MAgPIE was used for the update of the UN PRI's Inevitable Policy Response (IPR) project, updating the modelling with the most recent changes in policy and demand.
+    
+    Materials available at: https://ipr.transitionmonitor.com/
+    "
+    length: 15
+    presenter: Christian Mortlock
+    institution: Vivid Economics
+    country: United Kingdom
+  - title: "The Future of Food Prices: A Global Perspective on the Declining Importance of Agricultural Production Costs"
+    abstract: "Agricultural production costs make up less than half of total food prices for higher-income countries, and the farm share of food prices will likely further decrease globally. Added-value components such as transport, processing, marketing, and catering are of increasing importance in food value chains. Using a combined statistical and process-based modelling framework (the MAgPIE model), we derive and project the value-added component of food prices for 136 countries and 7 different food groups, for food-at-home and food-away-from-home. We confirm the declining importance of the producer share in consumer food prices across food products, and highlight the future evolution of consumer prices under a business-as-usual as well as a climate mitigation scenario."
+    length: 15
+    presenter: David Meng-Chuen Chen
+    institution: PIK
+    country: Germany
+---
+
+The second of two MAgPIE stories sessions in which MAgPIE user and developer
+share talk about their MAgPIE-based research and share their experiences (click
+on the arrows to see the abstracts for each talk).

--- a/_events/magpie24/d1_drop_in1.md
+++ b/_events/magpie24/d1_drop_in1.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title:  "Drop-in Session- Workshop 1/2"
+event_start:   "2024-04-11T16:00:00+01:00"
+event_end:     "2024-04-11T17:00:00+01:00"
+agenda:
+  - title: Interactive help session
+    length: 60
+    presenter: MAgPIE team
+---
+A drop-in session designed to provide an opportunity for attendees to ask questions about the previous days workshop. This is to ensure all attendees have had the opportunity to catch up on the previous days workshops.

--- a/_events/magpie24/d1_drop_in2.md
+++ b/_events/magpie24/d1_drop_in2.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title:  "Drop-in Session- Workshop 3/4"
+event_start:   "2024-04-12T15:00:00+01:00"
+event_end:     "2024-04-12T16:00:00+01:00"
+agenda:
+  - title: Interactive help session
+    length: 60
+    presenter: MAgPIE team
+---
+A drop-in session designed to provide an opportunity for attendees to ask questions about the previous days workshop. This is to ensure all attendees have had the opportunity to catch up on the previous days workshops.

--- a/_events/magpie24/d1_drop_in3.md
+++ b/_events/magpie24/d1_drop_in3.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title:  "Drop-in Session - Workshop 5/6"
+event_start:   "2024-04-15T15:00:00+01:00"
+event_end:     "2024-04-15T16:00:00+01:00"
+agenda:
+  - title: Interactive help session
+    length: 60
+    presenter: MAgPIE team
+---
+A drop-in session designed to provide an opportunity for attendees to ask questions about the previous days workshop. This is to ensure all attendees have had the opportunity to catch up on the previous days workshops.

--- a/_events/magpie24/e1_dinner.md
+++ b/_events/magpie24/e1_dinner.md
@@ -1,0 +1,11 @@
+---
+layout: event
+title:  "Dinner - In person"
+event_start:   "2024-04-10T17:00:00+01:00"
+agenda:
+  - title: Workshop dinner
+    length: 60
+    presenter: MAgPIE team
+---
+
+A conference dinner for in-person attendees. 

--- a/_magpie24/timetable.md
+++ b/_magpie24/timetable.md
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: Timetable
-permalink: /magpie22/timetable
-published: false
+permalink: /magpie24/timetable
+published: true
 ---
 
 
@@ -22,7 +22,7 @@ published: false
       timeZone: initialTimeZone,
       contentHeight: 700,
       initialView: 'listYear',
-      initialDate: '2022-03-04',
+      initialDate: '2024-04-10',
       headerToolbar: '',
       navLinks: true, // can click day/week names to navigate views
       editable: false,

--- a/people.md
+++ b/people.md
@@ -72,5 +72,11 @@ data:
     lastName: Crawford
     id: mc
     url: https://www.pik-potsdam.de/members/crawford
-
+  - firstName: Pascal
+    lastName: Sauer
+    id: ps
+    url: https://www.pik-potsdam.de/members/pascalfu
+  - firstName: David
+    lastName: Hötten
+    id: dh
 ---


### PR DESCRIPTION
Provisional timetable for MAgPIE24 workshop. Removed link to timetable from homepage but can be accessed via magpiemodel.github.io/magpie24/timetable