### PR TITLE
General website update in preparation for Workshop25

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,10 +45,10 @@ collections:
 # You need to restart jekyll for changes to have an effect
 socials:
   envelope: mailto:magpie@pik-potsdam.de
-  home: https://www.pik-potsdam.de/en/institute/departments/transformation-pathways/research/landuse
+  home: https://www.pik-potsdam.de/en/institute/labs/landuse
   github: https://github.com/magpiemodel/magpie
   wikipedia-w: https://en.wikipedia.org/wiki/MAgPIE
-  book: https://rse.pik-potsdam.de/doc/magpie/4.8.2
+  book: https://rse.pik-potsdam.de/doc/magpie/4.9.1
  
 # build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@
 			</ul>
 			<ul class="copyright">
 				<li><a href="impressum.html" target="_blank">Impressum</a></li>
-				<li>Content: <a href="https://www.pik-potsdam.de/en/institute/departments/transformation-pathways/research/landuse" target="_blank">Land Use Management @ PIK</a></li>
+				<li>Content: <a href="https://www.pik-potsdam.de/en/institute/labs/landuse" target="_blank">Land Use Transition Lab @ PIK</a></li>
 				<li>Design: <a href="https://html5up.net" target="_blank">HTML5 UP</a></li>
 				<li>Jekyll integration: <a href="https://github.com/andrewbanchich/forty-jekyll-theme" target="_blank">Andrew Banchich</a></li>
 

--- a/contributors.md
+++ b/contributors.md
@@ -14,7 +14,7 @@ data:
     id: hlc
     image: assets/images/team/lotzecampen.jpg
     url: https://www.pik-potsdam.de/members/hlotze
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Jan Philipp
     lastName: Dietrich
@@ -23,21 +23,19 @@ data:
     image: assets/images/team/dietrich.jpg
     affiliation: pik
     status: active
-    affiliaction: pik
-    status: active
   - firstName: Alexander
     lastName: Popp
     id: ap
     image: assets/images/team/popp.jpg
     url: https://www.pik-potsdam.de/members/popp
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Florian
     lastName: Humpenöder
     id: fh
     url: https://www.pik-potsdam.de/members/florianh
     image: assets/images/team/humpenoder.jpeg
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Abhijeet
     lastName: Mishra
@@ -50,14 +48,14 @@ data:
     id: fb
     image: assets/images/team/beier.jpeg
     url: https://www.pik-potsdam.de/members/beier
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Benjamin Leon
     lastName: Bodirsky
     id: bb
     image: assets/images/team/bodirsky.jpeg
     url: https://www.pik-potsdam.de/members/bodirsky
-    affiliaction: 
+    affiliation: 
       - pik 
     status: active
   - firstName: Edna Molina
@@ -65,49 +63,49 @@ data:
     id: emb
     url: https://www.pik-potsdam.de/members/mbacca
     image: assets/images/team/bacca.jpeg
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Kristine
     lastName: Karstens
     id: kk
     image: assets/images/team/karstens.jpeg
     url: https://www.pik-potsdam.de/members/karstens
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Pascal
     lastName: Sauer
     id: ma
     image: assets/images/team/sauer.jpeg
     url: https://www.pik-potsdam.de/members/pascalfu
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Patrick
     lastName: von Jeetze
     id: pj
     image: assets/images/team/vonjeetze.jpeg
     url: https://www.pik-potsdam.de/members/vjeetze
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Miodrag
     lastName: Stevanović
     id: ms
     image: assets/images/team/stevanovic.png
     url: https://www.pik-potsdam.de/members/miodrag
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Isabelle
     lastName: Weindl
     id: iw
     image: assets/images/team/weindl.jpeg
     url: https://www.pik-potsdam.de/members/weindl
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: David
     lastName: Klein
     id: dk
     image: assets/images/team/klein.jpeg
     url: https://www.pik-potsdam.de/members/dklein
-    affiliaction: 
+    affiliation: 
       - pik 
     status: active
   - firstName: Vartika
@@ -115,13 +113,13 @@ data:
     id: vs
     image: assets/images/team/singh.png
     url: https://www.pik-potsdam.de/members/vasingh
-    affiliaction: india 
+    affiliation: india 
     status: active
   - firstName: Jan
     lastName: Steinhauser
     id: js
     image: assets/images/team/steinhauser.jpg
-    affiliaction: 
+    affiliation: 
       - iiasa
     status: active
   - firstName: Michael
@@ -130,13 +128,13 @@ data:
     image: assets/images/team/windisch.jpeg
     url: https://www.pik-potsdam.de/members/windisch
     status: alumni
-    affiliaction: pik
+    affiliation: pik
   - firstName: Wang
     lastName: Xiaoxi
     id: wx
     image: assets/images/team/wang.jpeg
     url: https://www.pik-potsdam.de/members/wang
-    affiliaction: 
+    affiliation: 
       - china
     status: active
   - firstName: David Meng-Chuen
@@ -144,28 +142,28 @@ data:
     id: dc
     image: assets/images/team/chen.jpeg
     url: https://www.pik-potsdam.de/members/davidch
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Marcos
     lastName: Alves
     id: ma
     image: assets/images/team/alves.jpeg
     url: https://www.pik-potsdam.de/members/pedrosa
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Debbora
     lastName: Leip
     id: dl
     image: assets/images/team/leip.png
     url: https://www.pik-potsdam.de/members/dleip
-    affiliaction: pik
+    affiliation: pik
     status: active
   - firstName: Michael
     lastName: Crawford
     id: mc
     image: assets/images/team/crawford.jpeg
     url: https://www.pik-potsdam.de/members/crawford
-    affiliaction: 
+    affiliation: 
       - pik
       - foo
     status: active
@@ -174,42 +172,42 @@ data:
     id: ku
     image: assets/images/team/kreidenweis.jpeg
     url: https://www.pik-potsdam.de/members/kreidenweis
-    affiliaction: 
+    affiliation: 
       - pik 
     status: alumni
   - firstName: Ewerton
     lastName: Araujo
     id: ea
     image: assets/images/team/araujo.jpeg
-    affiliaction: 
+    affiliation: 
       - pik 
     status: alumni
   - firstName: Geanderson
     lastName: Ambrosio
     id: ag
     image: assets/images/team/ambrosio.jpeg
-    affiliaction: 
+    affiliation: 
       - pik 
     status: alumni
   - firstName: Anne
     lastName: Biewald
     id: ab
     image: assets/images/team/biewald.png
-    affiliaction: 
+    affiliation: 
       - pik 
     status: alumni
   - firstName: Alexandre
     lastName: Köberle
     id: ak
     image: assets/images/team/koberle.jpg
-    affiliaction: 
+    affiliation: 
       - pik 
     status: active
   - firstName: Jake
     lastName: Tommey
     id: jt
     image: assets/images/team/tommey.jpg
-    affiliaction: 
+    affiliation: 
       - pik
     status: active
 affiliations:


### PR DESCRIPTION
Updates include:
- updated links to https://www.pik-potsdam.de/en/institute/labs/landuse (current links are still forwarded there automatically)
- fixed `affiliaction` typo in contributors
- updated documentation link to the current MAgPIE version 4.9.1